### PR TITLE
Add markedJSONPath, prepend in error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [_Unreleased_](https://github.com/pbrisbin/yaml-marked/compare/v0.1.0.0...main)
 
+## [v0.2.0.0](https://github.com/pbrisbin/yaml-marked/compare/v0.1.0.0...v0.2.0.0)
+
+- Prepend errors with JSON path information
+- Add `markedJSONPath`
+
 ## [v0.1.0.0](https://github.com/pbrisbin/yaml-marked/tree/v0.1.0.0)
 
 First tagged release.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: yaml-marked
-version: 0.1.0.0
+version: 0.2.0.0
 synopsis: Support for parsing and rendering YAML documents with marks.
 description: Please see README.md
 category: Data

--- a/src/Data/Aeson/Compat.hs
+++ b/src/Data/Aeson/Compat.hs
@@ -3,16 +3,32 @@
 module Data.Aeson.Compat
 #if MIN_VERSION_aeson(2, 0, 0)
   ( module Data.Aeson
+  , parseEither
   ) where
 
 import Data.Aeson
+
+#if MIN_VERSION_aeson(2, 1, 0)
+import Prelude
+import Data.Aeson.Types (Parser, IResult(..), iparse)
+
+parseEither :: (a -> Parser b) -> a -> Either String b
+parseEither f a = case iparse f a of
+  IError _ x -> Left x
+  ISuccess b -> Right b
+#else
+import Data.Aeson.Types (parseEither)
+#endif
+
 #else
   ( Key
   , module Data.Aeson
+  , parseEither
   ) where
 
 import Data.Aeson
 import Data.Text (Text)
+import Data.Aeson.Types (parseEither)
 
 type Key = Text
 #endif

--- a/src/Data/Aeson/Compat/Key.hs
+++ b/src/Data/Aeson/Compat/Key.hs
@@ -11,7 +11,7 @@ module Data.Aeson.Compat.Key
 import Data.Aeson.Key
 #else
 import Prelude (id)
-import Data.Text (Text, unpac)
+import Data.Text (Text, unpack)
 
 type Key = Text
 

--- a/src/Data/Aeson/Compat/Key.hs
+++ b/src/Data/Aeson/Compat/Key.hs
@@ -4,13 +4,14 @@ module Data.Aeson.Compat.Key
   ( Key
   , fromText
   , toText
+  , toString
   ) where
 
 #if MIN_VERSION_aeson(2, 0, 0)
 import Data.Aeson.Key
 #else
 import Prelude (id)
-import Data.Text (Text)
+import Data.Text (Text, unpac)
 
 type Key = Text
 
@@ -19,4 +20,7 @@ fromText = id
 
 toText :: Key -> Text
 toText = id
+
+toString :: Key -> String
+toString = unpack . toText
 #endif

--- a/src/Data/Aeson/Compat/Key.hs
+++ b/src/Data/Aeson/Compat/Key.hs
@@ -10,7 +10,7 @@ module Data.Aeson.Compat.Key
 #if MIN_VERSION_aeson(2, 0, 0)
 import Data.Aeson.Key
 #else
-import Prelude (id)
+import Prelude
 import Data.Text (Text, unpack)
 
 type Key = Text

--- a/src/Data/Yaml/Marked.hs
+++ b/src/Data/Yaml/Marked.hs
@@ -9,12 +9,14 @@ module Data.Yaml.Marked
 
 import Prelude
 
+import Data.Aeson (JSONPath)
 import Numeric.Natural
 import Text.Libyaml (Event, MarkedEvent (..), YamlMark (..))
 
 data Marked a = Marked
   { markedItem :: a
   , markedPath :: FilePath
+  , markedJSONPath :: Maybe JSONPath
   , markedLocationStart :: Location
   -- ^ Location of the first character of the item
   --
@@ -59,6 +61,7 @@ fromMarkedEvent MarkedEvent {..} fp =
   Marked
     { markedItem = yamlEvent
     , markedPath = fp
+    , markedJSONPath = Nothing
     , markedLocationStart = locationFromYamlMark yamlStartMark
     , markedLocationEnd = locationFromYamlMark yamlEndMark
     }

--- a/src/Data/Yaml/Marked/Value.hs
+++ b/src/Data/Yaml/Marked/Value.hs
@@ -11,8 +11,7 @@ import Prelude
 import Data.Aeson (FromJSON (..))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Compat.KeyMap (KeyMap)
-import Data.Aeson.Types (iparseEither)
-import Data.Bifunctor (first)
+import Data.Aeson.Types (IResult (..), Parser, iparse)
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 import Data.Vector (Vector)
@@ -33,7 +32,12 @@ type MarkedArray = Vector (Marked Value)
 
 -- | Parse the value using its 'FromJSON', discarding any marks
 valueAsJSON :: FromJSON a => Value -> Either String a
-valueAsJSON = first snd . iparseEither parseJSON . valueToValue
+valueAsJSON = parseEither parseJSON . valueToValue
+
+parseEither :: (a -> Parser b) -> a -> Either String b
+parseEither f a = case iparse f a of
+  IError _ x -> Left x
+  ISuccess b -> Right b
 
 -- | Convert a 'Value' to an equivalent 'Data.Aeson.Value'
 valueToValue :: Value -> Aeson.Value

--- a/src/Data/Yaml/Marked/Value.hs
+++ b/src/Data/Yaml/Marked/Value.hs
@@ -11,7 +11,8 @@ import Prelude
 import Data.Aeson (FromJSON (..))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Compat.KeyMap (KeyMap)
-import Data.Aeson.Types (parseEither)
+import Data.Aeson.Types (iparseEither)
+import Data.Bifunctor (first)
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 import Data.Vector (Vector)
@@ -32,7 +33,7 @@ type MarkedArray = Vector (Marked Value)
 
 -- | Parse the value using its 'FromJSON', discarding any marks
 valueAsJSON :: FromJSON a => Value -> Either String a
-valueAsJSON = parseEither parseJSON . valueToValue
+valueAsJSON = first snd . iparseEither parseJSON . valueToValue
 
 -- | Convert a 'Value' to an equivalent 'Data.Aeson.Value'
 valueToValue :: Value -> Aeson.Value

--- a/src/Data/Yaml/Marked/Value.hs
+++ b/src/Data/Yaml/Marked/Value.hs
@@ -10,8 +10,8 @@ import Prelude
 
 import Data.Aeson (FromJSON (..))
 import qualified Data.Aeson as Aeson
+import Data.Aeson.Compat (parseEither)
 import Data.Aeson.Compat.KeyMap (KeyMap)
-import Data.Aeson.Types (IResult (..), Parser, iparse)
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 import Data.Vector (Vector)
@@ -33,11 +33,6 @@ type MarkedArray = Vector (Marked Value)
 -- | Parse the value using its 'FromJSON', discarding any marks
 valueAsJSON :: FromJSON a => Value -> Either String a
 valueAsJSON = parseEither parseJSON . valueToValue
-
-parseEither :: (a -> Parser b) -> a -> Either String b
-parseEither f a = case iparse f a of
-  IError _ x -> Left x
-  ISuccess b -> Right b
 
 -- | Convert a 'Value' to an equivalent 'Data.Aeson.Value'
 valueToValue :: Value -> Aeson.Value

--- a/yaml-marked.cabal
+++ b/yaml-marked.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           yaml-marked
-version:        0.1.0.0
+version:        0.2.0.0
 synopsis:       Support for parsing and rendering YAML documents with marks.
 description:    Please see README.md
 category:       Data


### PR DESCRIPTION
This is wildly tricky.

When aeson does it's parsing in `Parser` it knows the current 'JSONPath'
as part of state. Failure can then be handled in an overall way with the
current set of `JSONPath` values (such as `$`, `$.foo`, `$.foo.0`) as
part of running the `Parser`, finally rendering (e.g.) `Error in
$['foo'][0]` at the end.

This is what we're recreating.

However, we don't have `Parser` (just `Either String`). Further, we
parse the events to a `Marked Value` first, completely, then parse from
that later.

This causes two problems that we deal with separately:

1. We don't have `JSONPath` where we need it (when handling `Marked
   Value`s). To solve that, we added `markedJSONPath`. This is a
   breaking change.

2. As we prepend each of `$`, `$.foo`, and `$.foo.0` to our errors we
   never get to see them all at once (where one may like to, say, "take
   longest"), we have to prepend then one at a time, which means we need
   to avoid producing, `$.$.foo.$.foo.0`. To solve this, we only prepend
   the last element of any given path, assuming leading elements will
   then get prepended on their own. Lastly, we use the `[` character in
   the thing we're prepending onto, to know if we should add the `: `
   separator or not.

Phew.